### PR TITLE
fix: Resolve build issues and add PDF parsing

### DIFF
--- a/app/api/parse-pdf/route.ts
+++ b/app/api/parse-pdf/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import pdf from "pdf-parse";
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get("file");
+
+    if (!file || !(file instanceof File)) {
+      return NextResponse.json({ error: "No file uploaded" }, { status: 400 });
+    }
+
+    const fileBuffer = Buffer.from(await file.arrayBuffer());
+    const data = await pdf(fileBuffer);
+
+    return NextResponse.json({ text: data.text });
+  } catch (error) {
+    console.error("Parse-pdf error:", error);
+    return NextResponse.json(
+      { error: "Failed to parse PDF" },
+      { status: 500 }
+    );
+  }
+}

--- a/components/ResumeUpload.tsx
+++ b/components/ResumeUpload.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useToast } from "@/components/ui/use-toast";
 
@@ -122,7 +121,7 @@ export default function ResumeUpload({ onResumeUploaded }: ResumeUploadProps) {
           <input
             id="file-upload"
             type="file"
-            accept=".txt"
+            accept=".pdf, .txt"
             onChange={handleChange}
             className="hidden"
             disabled={uploading}

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,12 @@ const nextConfig: NextConfig = {
   typescript: {
     // ignoreBuildErrors: true,
   },
+  webpack: (config, { isServer }) => {
+    if (isServer) {
+      config.externals = [...config.externals, "pdf-parse"];
+    }
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "typescript": "^5.0.0"
       },
       "devDependencies": {
+        "@types/pdf-parse": "^1.1.5",
         "eslint": "^8.0.0",
         "eslint-config-next": "15.0.3"
       }
@@ -1401,6 +1402,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/pdf-parse": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/pdf-parse/-/pdf-parse-1.1.5.tgz",
+      "integrity": "sha512-kBfrSXsloMnUJOKi25s3+hRmkycHfLK6A09eRGqF/N8BkQoPUmaCr+q8Cli5FnfohEz/rsv82zAiPz/LXtOGhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/phoenix": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@google/genai": "^1.11.0",
@@ -34,6 +34,7 @@
     "typescript": "^5.0.0"
   },
   "devDependencies": {
+    "@types/pdf-parse": "^1.1.5",
     "eslint": "^8.0.0",
     "eslint-config-next": "15.0.3"
   }


### PR DESCRIPTION
This change resolves several issues that were causing the build to fail and completes the implementation of PDF parsing for resume uploads.

- A new API endpoint `/api/parse-pdf` has been created to handle PDF parsing on the server-side using the `pdf-parse` library.
- The resume upload component has been updated to allow `.pdf` file types in the file input.
- Added `@types/pdf-parse` to provide TypeScript definitions for the `pdf-parse` library.
- Updated the `next.config.ts` to treat `pdf-parse` as an external module, fixing a build-time error.
- Changed the `lint` script in `package.json` to use `eslint .` directly.
- Fixed a minor linting issue (unused import) in the upload component.